### PR TITLE
Add flatpak

### DIFF
--- a/data/io.github.hugopl.rtfm.desktop
+++ b/data/io.github.hugopl.rtfm.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Type=Application
 Exec=rtfm
-Name=Rtfm
+Name=Read the Formidable Manual
 GenericName=Offline documentation browser
 Terminal=false
 Icon=io.github.hugopl.rtfm

--- a/data/io.github.hugopl.rtfm.json
+++ b/data/io.github.hugopl.rtfm.json
@@ -1,0 +1,160 @@
+{
+    "app-id": "io.github.hugopl.rtfm",
+    "runtime": "org.gnome.Platform",
+    "runtime-version": "44",
+    "sdk": "org.gnome.Sdk",
+    "command": "rtfm",
+    "finish-args": [
+        "--socket=wayland",
+        "--socket=fallback-x11",
+        "--share=ipc",
+        "--device=dri"
+    ],
+    "cleanup": [
+        "/include",
+        "/lib/pkgconfig",
+        "/share/doc",
+        "/share/man",
+        "*.a",
+        "*.la"
+    ],
+    "modules": [
+        {
+            "name": "livevent",
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/libevent/libevent.git",
+                    "tag": "release-2.1.12-stable"
+                }
+            ]
+        },
+        {
+            "name": "libyaml",
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/yaml/libyaml/releases/download/0.2.5/yaml-0.2.5.tar.gz",
+                    "sha256": "c642ae9b75fee120b2d96c712538bd2cf283228d2337df2cf2988e3c02678ef4"
+                }
+            ]
+        },
+        {
+            "name": "rtfm",
+            "buildsystem": "simple",
+            "build-options": {
+                "append-path": "/run/build/rtfm/crystal/bin/"
+            },
+            "build-commands": [
+                "mv ./crystal-docs/crystal-*-docs/ ./crystal-docs/docs/",
+                "crystal run src/create_crystal_docset.cr -- ./crystal-docs/docs/",
+                "for i in ./lib/*/; do ln -snf \"..\" \"$i/lib\"; done",
+                "cd lib/gi-crystal && crystal build src/generator/main.cr && cd ../.. && mkdir ./bin && cp lib/gi-crystal/main ./bin/gi-crystal",
+                "./bin/gi-crystal",
+                "crystal build ./src/main.cr -o rtfm"
+            ],
+            "post-install": [
+                "mkdir -p /app/share/rtfm/docsets/ && cp -rv data/Crystal.docset /app/share/rtfm/docsets/",
+                "install -D -m 0755 rtfm /app/bin/rtfm",
+                "install -D -m 0644 data/io.github.hugopl.rtfm.desktop /app/share/applications/io.github.hugopl.rtfm.desktop",
+                "install -D -m 0644 data/icons/hicolor/scalable/apps/io.github.hugopl.rtfm.svg /app/share/icons/hicolor/scalable/apps/io.github.hugopl.rtfm.svg",
+                "install -D -m 0644 data/io.github.hugopl.rtfm.metainfo.xml /app/share/metainfo/io.github.hugopl.rtfm.metainfo.xml",
+                "install -D -m 0644 data/io.github.hugopl.rtfm.gschema.xml /app/share/glib-2.0/schemas/io.github.hugopl.rtfm.gschema.xml",
+                "glib-compile-schemas /app/share/glib-2.0/schemas"
+            ],
+            "sources": [
+                {
+                    "type": "dir",
+                    "path": "..",
+                    "skip": [
+                        ".rucksack",
+                        ".rucksack.toc",
+                        "lib/",
+                        "rtfm",
+                        "bin/",
+                        "data/io.github.hugopl.rtfm.gresource",
+                        "po/mo/"
+                    ]
+                },
+                {
+                    "type": "archive",
+                    "dest": "crystal/",
+                    "url": "https://github.com/crystal-lang/crystal/releases/download/1.8.2/crystal-1.8.2-1-linux-x86_64.tar.gz",
+                    "sha256": "17be39072d47073d5869181f96aed853dc711598b972a837527725e17d6b007e",
+                    "only_arches": [
+                        "x86_64"
+                    ]
+                },
+                {
+                    "type": "archive",
+                    "dest": "crystal/",
+                    "url": "https://github.com/geopjr-forks/crystal-aarch64/releases/download/v1.8.2/crystal-1.8.2-1-linux-aarch64.tar.xz",
+                    "sha256": "5d5095fe3635bf85389fac1c716134d4c1965d923770aef51b8fd60346816a8a",
+                    "only_arches": [
+                        "aarch64"
+                    ]
+                },
+                {
+                    "type": "archive",
+                    "dest": "crystal-docs/",
+                    "url": "https://github.com/crystal-lang/crystal/releases/download/1.8.2/crystal-1.8.2-docs.tar.gz",
+                    "sha256": "662dc3515ee2af2522843acf561fc68b1e3d4baac1750bc3131ce91099b46a24"
+                },
+                {
+                    "type": "git",
+                    "url": "https://github.com/crystal-lang/crystal-db.git",
+                    "tag": "v0.12.0",
+                    "dest": "lib/db"
+                },
+                {
+                    "type": "git",
+                    "url": "https://github.com/hugopl/fzy.git",
+                    "tag": "v0.5.5",
+                    "dest": "lib/fzy"
+                },
+                {
+                    "type": "git",
+                    "url": "https://github.com/hugopl/gi-crystal.git",
+                    "commit": "4b38b6597fa9fc0e77028c5ed9ea31be9795a6d8",
+                    "dest": "lib/gi-crystal"
+                },
+                {
+                    "type": "git",
+                    "url": "https://github.com/hugopl/gio.cr.git",
+                    "tag": "v0.1.0",
+                    "dest": "lib/gio"
+                },
+                {
+                    "type": "git",
+                    "url": "https://github.com/hugopl/gtk4.cr.git",
+                    "commit": "83c6921fc6b9916f3ff43e27d8b9d8ecda5f85d1",
+                    "dest": "lib/gtk4"
+                },
+                {
+                    "type": "git",
+                    "url": "https://github.com/hugopl/harfbuzz.cr.git",
+                    "tag": "v0.1.0",
+                    "dest": "lib/harfbuzz"
+                },
+                {
+                    "type": "git",
+                    "url": "https://github.com/geopjr/libadwaita.cr.git",
+                    "commit": "23ce21d6400af7563ede0b53deea6d1f77436985",
+                    "dest": "lib/libadwaita"
+                },
+                {
+                    "type": "git",
+                    "url": "https://github.com/hugopl/pango.cr.git",
+                    "tag": "v0.2.0",
+                    "dest": "lib/pango"
+                },
+                {
+                    "type": "git",
+                    "url": "https://github.com/crystal-lang/crystal-sqlite3.git",
+                    "tag": "v0.20.0",
+                    "dest": "lib/sqlite3"
+                }
+            ]
+        }
+    ]
+}

--- a/data/io.github.hugopl.rtfm.json
+++ b/data/io.github.hugopl.rtfm.json
@@ -115,7 +115,7 @@
                 {
                     "type": "git",
                     "url": "https://github.com/hugopl/gi-crystal.git",
-                    "commit": "4b38b6597fa9fc0e77028c5ed9ea31be9795a6d8",
+                    "commit": "9ebef9964b52a2646533c8a8c1a6730492f78674",
                     "dest": "lib/gi-crystal"
                 },
                 {

--- a/data/io.github.hugopl.rtfm.json
+++ b/data/io.github.hugopl.rtfm.json
@@ -3,6 +3,9 @@
     "runtime": "org.gnome.Platform",
     "runtime-version": "44",
     "sdk": "org.gnome.Sdk",
+    "sdk-extensions": [
+        "org.gnome.Sdk.Docs"
+    ],
     "command": "rtfm",
     "finish-args": [
         "--socket=wayland",
@@ -48,13 +51,14 @@
             "build-commands": [
                 "mv ./crystal-docs/crystal-*-docs/ ./crystal-docs/docs/",
                 "crystal run src/create_crystal_docset.cr -- ./crystal-docs/docs/",
+                "crystal run src/create_gtk_docset.cr",
                 "for i in ./lib/*/; do ln -snf \"..\" \"$i/lib\"; done",
                 "cd lib/gi-crystal && crystal build src/generator/main.cr && cd ../.. && mkdir ./bin && cp lib/gi-crystal/main ./bin/gi-crystal",
                 "./bin/gi-crystal",
                 "crystal build ./src/main.cr -o rtfm"
             ],
             "post-install": [
-                "mkdir -p /app/share/rtfm/docsets/ && cp -rv data/Crystal.docset /app/share/rtfm/docsets/",
+                "mkdir -p /app/share/rtfm/docsets/ && cp -rv data/*.docset /app/share/rtfm/docsets/",
                 "install -D -m 0755 rtfm /app/bin/rtfm",
                 "install -D -m 0644 data/io.github.hugopl.rtfm.desktop /app/share/applications/io.github.hugopl.rtfm.desktop",
                 "install -D -m 0644 data/icons/hicolor/scalable/apps/io.github.hugopl.rtfm.svg /app/share/icons/hicolor/scalable/apps/io.github.hugopl.rtfm.svg",

--- a/data/io.github.hugopl.rtfm.metainfo.xml
+++ b/data/io.github.hugopl.rtfm.metainfo.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop">
+  <id>io.github.hugopl.rtfm</id>
+  <name>Read the Formidable Manual</name>
+  <project_license>MIT</project_license>
+  <developer_name translatable="no">Hugo Parente Lima</developer_name>
+  <summary>GNOME dash docset documentation reader</summary>
+  <metadata_license>CC0-1.0</metadata_license>
+  <url type="homepage">https://github.com/hugopl/rtfm</url>
+  <url type="bugtracker">https://github.com/hugopl/rtfm/issues</url>
+  <url type="donation">https://github.com/sponsors/hugopl</url>
+  <description>
+    <p>
+      A dash/docset reader with built in documentation for Crystal and GTK APIs
+    </p>
+  </description>
+  <screenshots>
+    <screenshot type="default">
+      <image type="source">https://raw.githubusercontent.com/hugopl/rtfm/main/screenshots/prerelease.png</image>
+    </screenshot>
+  </screenshots>
+  <releases>
+    <release version="0.1.0" date="2023-07-07">
+      <description>
+        <ul>
+          <li>Initial Release</li>
+        </ul>
+      </description>
+    </release>
+  </releases>
+  <content_rating type="oars-1.1" />
+  <translation type="gettext">io.github.hugopl.rtfm</translation>
+  <custom>
+    <value key="Purism::form_factor">workstation</value>
+    <!-- <value key="Purism::form_factor">mobile</value> -->
+  </custom>
+  <requires>
+    <display_length compare="ge">816</display_length>
+    <!-- <display_length compare="ge">360</display_length> -->
+  </requires>
+  <recommends>
+    <control>keyboard</control>
+    <control>pointing</control>
+    <!-- <control>touch</control> -->
+  </recommends>
+</component>


### PR DESCRIPTION
I don't think it's ready yet but here's a first try!

- aarch64 crystal binaries are maintained by me, I don't know if they have any other issues (I use crystal's distribution scripts to build them) but they seem to work nicely for Collision (https://github.com/geopjr-forks/crystal-aarch64)
- shards are generated from the lockfile + lib/ (for postscripts) using https://github.com/GeopJr/Collision/blob/main/data/scripts/shards_to_sources.cr
- building gi-crystal is a bit messy but it works
- I filled the metainfo file, some info might be wrong (I commented out the mobile ones as rtfm is not mobile-szie-friendly yet)


This is not flat**hub** ready yet:
- [x] figure out permissions (are glib docsets on host? can they be included in the flatpak instead of opening a hole in the sandbox?)
- [ ] use yaml for flat**hub**
- [ ] use x-checker-data for flat**hub** (auto checks and opens PRs when sources (rtfm) get new releases)
- [ ] set up a ci for nightly builds? (might be better after some specs are added)

you can give it a try on your machine by running:
```
$ flatpak-builder ./build ./data/io.github.hugopl.rtfm.json --user --install --force-clean
$ flatpak run io.github.hugopl.rtfm