### PR TITLE
Fix crash when trying to open any doc.

### DIFF
--- a/shard.lock
+++ b/shard.lock
@@ -1,4 +1,3 @@
-# NOTICE: This lockfile contains some overrides from shard.override.yml
 version: 2.0
 shards:
   db:
@@ -11,15 +10,15 @@ shards:
 
   gi-crystal:
     git: https://github.com/hugopl/gi-crystal.git
-    version: 0.17.0
+    version: 0.20.0
 
   gio:
     git: https://github.com/hugopl/gio.cr.git
-    version: 0.1.0
+    version: 0.2.0
 
-  gtk4: # Overridden
+  gtk4:
     git: https://github.com/hugopl/gtk4.cr.git
-    version: 0.15.0
+    version: 0.16.0
 
   harfbuzz:
     git: https://github.com/hugopl/harfbuzz.cr.git
@@ -27,11 +26,11 @@ shards:
 
   libadwaita:
     git: https://github.com/geopjr/libadwaita.cr.git
-    version: 1.0.0+git.commit.23ce21d6400af7563ede0b53deea6d1f77436985
+    version: 1.0.0+git.commit.cffabb56e911d2a90c53c2fd14d6bd08bf5ac446
 
   pango:
     git: https://github.com/hugopl/pango.cr.git
-    version: 0.2.0
+    version: 0.3.0
 
   sqlite3:
     git: https://github.com/crystal-lang/crystal-sqlite3.git

--- a/shard.override.yml
+++ b/shard.override.yml
@@ -1,4 +1,0 @@
-dependencies:
-  gtk4:
-    github: hugopl/gtk4.cr
-    version: ~> 0.15.0

--- a/shard.yml
+++ b/shard.yml
@@ -14,7 +14,7 @@ dependencies:
     version: ~> 0.5
   libadwaita:
     github: GeopJr/libadwaita.cr
-    branch: main
+    commit: cffabb56e911d2a90c53c2fd14d6bd08bf5ac446
   sqlite3:
     github: crystal-lang/crystal-sqlite3
     version: ~>0.20.0


### PR DESCRIPTION
This crash only happens with GTK4 > ~4.6, it's caused by a bug in gi-crystal that didn't crash before by pure luck.

Fixes #12