### PR TITLE
Update shard.lock: gio 0.2.0 -> 0.2.1

### DIFF
--- a/shard.lock
+++ b/shard.lock
@@ -14,7 +14,7 @@ shards:
 
   gio:
     git: https://github.com/hugopl/gio.cr.git
-    version: 0.2.0
+    version: 0.2.1
 
   gtk4:
     git: https://github.com/hugopl/gtk4.cr.git


### PR DESCRIPTION
Fixed runtime gresource compile error by updating `gio`
```bash
--: line 1: glib-compile-resources: command not found
Unhandled exception: Error opening file with mode 'r': 'crystal-gio-resource.gresource': No such file or directory (File::NotFoundError)
```