### PR TITLE
Release v0.5.0.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - 2024-06-24
+### Added
+- Add documentation for GLib, Gio and GObject.
+
+### Fixed
+- Fixed document hierarchy for Struct, Namespace and Mixin documents.
+- Remove -Dpreview_mt to improve stability and add few other compiler options.
+
 ## [0.4.1] - 2024-05-03
 ### Added
 - It's possible to launch rtfm with a query, meanwhile the default docset is used.

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: rtfm
-version: 0.4.1
+version: 0.5.0
 
 authors:
   - Hugo Parente Lima <hugo.pl@gmail.com>


### PR DESCRIPTION
### Added
- Add documentation for GLib, Gio and GObject.

### Fixed
- Fixed document hierarchy for Struct, Namespace and Mixin documents.
- Remove -Dpreview_mt to improve stability and add few other compiler options.
