### PR TITLE
Release v0.5.1.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.1] - 2024-08-26
+### Added
+- Add Alt+Up/Down shortcut to select previous/next docset in locator dialog.
+
+### Fixed
+- Only link to necessary libraries directly used by rtfm, thanks.
+- Log unhandled exceptions before quit on errors.
+- Do not hide locator if nothing was loaded yet.
+- Fix some keyboard focus issues.
+
 ## [0.5.0] - 2024-06-24
 ### Added
 - Add documentation for GLib, Gio and GObject.

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: rtfm
-version: 0.5.0
+version: 0.5.1
 
 authors:
   - Hugo Parente Lima <hugo.pl@gmail.com>


### PR DESCRIPTION
### Added
- Add Alt+Up/Down shortcut to select previous/next docset in locator dialog.

### Fixed
- Only link to necessary libraries directly used by rtfm, thanks.
- Log unhandled exceptions before quit on errors.
- Do not hide locator if nothing was loaded yet.
- Fix some keyboard focus issues.
